### PR TITLE
 Fixes #1 for has()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+3.0.4
+- Fixes Issue #1
+if the unique ID is not in the container, has() bails out returning false without checking for the item keys.
+
 3.0.3
 - Added `store` method
 - Added "dot" notation capability

--- a/src/Container/DIContainer.php
+++ b/src/Container/DIContainer.php
@@ -77,6 +77,7 @@ class DIContainer extends Pimple implements ContainerContract
      *
      * @since 3.0.0
      * @since 3.0.3 "dot" notation
+     * @since 3.0.4 Issue #1
      *
      * @param  string $uniqueId The unique identifier for the parameter or object
      * @param string|null $itemKeys Keys within the item, which can be "dot" notation.

--- a/src/Container/DIContainer.php
+++ b/src/Container/DIContainer.php
@@ -86,6 +86,9 @@ class DIContainer extends Pimple implements ContainerContract
     public function has($uniqueId, $itemKeys = null)
     {
         $hasUniqueId = $this->offsetExists($uniqueId);
+        if ($hasUniqueId !== true) {
+            return false;
+        }
 
         // If there are itemKeys, check deeply.
         if (!empty($itemKeys) && is_string($itemKeys)) {

--- a/tests/Unit/Container/ContainerHasTest.php
+++ b/tests/Unit/Container/ContainerHasTest.php
@@ -38,7 +38,7 @@ class ContainerHasTest extends UnitTestCase
         $this->assertTrue($container->has('some_array'));
     }
 
-    public function testContainerShouldNotValues()
+    public function testContainerShouldNotFindValues()
     {
         $initialParameters = [
             'foo' => 'Hello World',
@@ -72,6 +72,7 @@ class ContainerHasTest extends UnitTestCase
             ],
         ]);
 
+        $this->assertFalse($container->has('bar', 'baz'));
         $this->assertTrue($container->has('foo', 'baz'));
         $this->assertTrue($container->has('foo', 'bar'));
         $this->assertTrue($container->has('foo', 'bar.baz'));

--- a/tests/Unit/Container/ContainerHasTest.php
+++ b/tests/Unit/Container/ContainerHasTest.php
@@ -72,7 +72,11 @@ class ContainerHasTest extends UnitTestCase
             ],
         ]);
 
+        // Test for Issue #1.
         $this->assertFalse($container->has('bar', 'baz'));
+        $this->assertFalse($container->has('bar', 'bar.baz'));
+        $this->assertFalse($container->has('doesnotexist', 'bar.baz'));
+
         $this->assertTrue($container->has('foo', 'baz'));
         $this->assertTrue($container->has('foo', 'bar'));
         $this->assertTrue($container->has('foo', 'bar.baz'));

--- a/tests/Unit/Container/ContainerRegisterConcreteTest.php
+++ b/tests/Unit/Container/ContainerRegisterConcreteTest.php
@@ -124,4 +124,19 @@ class ContainerRegisterConcreteTest extends UnitTestCase
         $this->assertInstanceOf('stdClass', $foo);
         $this->assertEquals('some value', $foo->bar);
     }
+
+    public function testShouldPassContainerToConcrete()
+    {
+        $container = new DIContainer();
+
+        $concreteConfig = [
+            'autoload' => true,
+            'concrete' => function ($container) {
+                return $container;
+            },
+        ];
+
+        $foo = $container->registerConcrete($concreteConfig, 'foo');
+        $this->assertInstanceOf('Fulcrum\Container\DIContainer', $foo);
+    }
 }


### PR DESCRIPTION
Fixes #1 - if the unique ID is not in the container, `has()` bails out returning false without checking for the item keys.